### PR TITLE
[FIX] FIxed incorrect fields.datetime.now()

### DIFF
--- a/integration_queue_job/models/queue_job.py
+++ b/integration_queue_job/models/queue_job.py
@@ -426,7 +426,7 @@ class QueueJob(models.Model):
 
     def _get_stuck_jobs_domain(self, queue_dl, started_dl):
         domain = []
-        now = fields.datetime.now()
+        now = fields.Datetime.now()
         if queue_dl:
             queue_dl = now - timedelta(minutes=queue_dl)
             domain.append(


### PR DESCRIPTION
Due tue ERROR
2025-09-24 09:54:56,743 31885 ERROR cloud odoo.addons.base.models.ir_cron: Job 'Jobs Garbage Collector' (34) server action #435 failed 
Traceback (most recent call last):
  File "/opt/19.0/odoo/odoo/tools/safe_eval.py", line 397, in safe_eval
    return unsafe_eval(c, globals_dict, None)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "ir.actions.server(435,)", line 1, in <module>
  File "/opt/19.0/integration-queue/integration_queue_job/models/queue_job.py", line 422, in requeue_stuck_jobs
    self._get_stuck_jobs_to_requeue(
  File "/opt/19.0/integration-queue/integration_queue_job/models/queue_job.py", line 457, in _get_stuck_jobs_to_requeue
    self._get_stuck_jobs_domain(enqueued_delta, started_delta)
  File "/opt/19.0/integration-queue/integration_queue_job/models/queue_job.py", line 429, in _get_stuck_jobs_domain
    now = fields.datetime.now()
          ^^^^^^^^^^^^^^^
AttributeError: module 'odoo.fields' has no attribute 'datetime'. Did you mean: 'Datetime'?

Was added fix