### PR TITLE
[ADD] OCA queue_job compatibility bridge module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,104 @@
+# Integration Queue — Background Jobs for VentorTech Connectors
+
+This repository provides background job processing support for
+[VentorTech e-commerce connectors](https://ventor.tech) (WooCommerce,
+PrestaShop, Magento 2, Shopify) on Odoo 19.0.
+
+It contains **two modules** with different purposes:
+
+---
+
+## Modules
+
+### `integration_queue_job` — Standalone Fork
+
+A self-contained background jobs module forked from
+[OCA's Job Queue](https://github.com/OCA/queue).  This is the **default
+dependency** of VentorTech connectors and the simplest option when OCA's
+`queue_job` is **not** already installed in your environment.
+
+**Use this module when:**
+- You are installing VentorTech connectors on a fresh Odoo instance.
+- OCA's `queue_job` is not already present in your add-on path.
+
+---
+
+### `integration_queue_job_bridge` — OCA Compatibility Bridge
+
+A lightweight shim that delegates everything to OCA's
+[`queue_job`](https://github.com/OCA/queue) module.  It creates the XML-ID
+aliases that VentorTech connector modules rely on so that **no changes are
+needed** in any connector module when switching from the standalone fork to
+OCA's implementation.
+
+**Use this module when:**
+- OCA's `queue_job` is already installed (or preferred) in your environment.
+- You want to avoid maintaining a fork and stay on the official OCA module.
+
+---
+
+## Switching from `integration_queue_job` to OCA `queue_job`
+
+Follow these steps to replace the standalone fork with OCA's module while
+keeping all VentorTech connectors working without any code changes.
+
+### Prerequisites
+
+- OCA's `queue_job` module (Odoo 19.0 branch) available in your add-on path.
+  Repository: https://github.com/OCA/queue
+
+### Step-by-step
+
+1. **Copy and rename the bridge module.**
+
+   Copy `integration_queue_job_bridge` from this repository into your Odoo
+   add-ons directory and rename the copy to `integration_queue_job`:
+
+   ```bash
+   cp -r integration_queue_job_bridge /path/to/your/addons/integration_queue_job
+   ```
+
+   The technical name **must** be `integration_queue_job` because that is the
+   name referenced in all VentorTech connector manifests and XML files.
+
+2. **Uninstall the old standalone module.**
+
+   In Odoo's Apps menu, uninstall `Integration Queue Job` (the standalone
+   fork).  Odoo will also uninstall all VentorTech connector modules that
+   depend on it — this is expected.
+
+3. **Install OCA's `queue_job`.**
+
+   Install the OCA *Job Queue* module from your add-ons list.
+
+4. **Install the bridge (renamed to `integration_queue_job`).**
+
+   Install the module you renamed in step 1.  Its `post_init_hook` will
+   automatically create the XML-ID aliases that connectors need
+   (`integration_queue_job.channel_root`,
+   `integration_queue_job.group_queue_job_manager`).
+
+5. **Reinstall VentorTech connectors.**
+
+   Reinstall the connector modules (e.g. *Odoo E-Commerce Connector Core* and
+   any specific connector like WooCommerce or Shopify).  No changes to their
+   manifest, XML, or Python files are required.
+
+### What the bridge does internally
+
+The bridge's `post_init_hook` creates `ir.model.data` alias records:
+
+| Alias XML ID | Points to |
+|---|---|
+| `integration_queue_job.channel_root` | `queue_job.channel_root` |
+| `integration_queue_job.group_queue_job_manager` | `queue_job.group_queue_job_manager` |
+
+These aliases make every XML `ref=`, `groups=`, and Python `env.ref()` call
+that uses the `integration_queue_job.*` prefix resolve to the correct records
+owned by OCA's module — transparently and without touching any connector code.
+
+---
+
+## License
+
+LGPL-3.0 or later — see individual file headers for full copyright notices.

--- a/integration_queue_job_bridge/__init__.py
+++ b/integration_queue_job_bridge/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 VentorTech (https://ventor.tech)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from .post_init_hook import post_init_hook
+
+# Re-export the symbols that VentorTech connectors import directly from
+# this package, keeping the same public API as integration_queue_job.
+from odoo.addons.queue_job.job import identity_exact  # noqa: F401

--- a/integration_queue_job_bridge/__manifest__.py
+++ b/integration_queue_job_bridge/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 VentorTech (https://ventor.tech)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+# NOTE: This module is intended to be copied and renamed to
+# "integration_queue_job" before use. See README.md for full instructions.
+
+{
+    'name': 'Integration Queue Job Bridge (OCA)',
+    'summary': '''Compatibility bridge that allows VentorTech integration connectors
+to work with OCA\'s Job Queue module instead of the built-in integration_queue_job fork.
+''',
+    'version': '19.0.1.0.0',
+    'author': 'VentorTech',
+    'website': 'https://github.com/ventor-dev/integration-queue',
+    'license': 'LGPL-3',
+    'category': 'Tools',
+    'depends': ['queue_job'],
+    'installable': True,
+    'application': False,
+    'maintainers': ['ventor-dev'],
+    'post_init_hook': 'post_init_hook',
+}

--- a/integration_queue_job_bridge/exception.py
+++ b/integration_queue_job_bridge/exception.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 VentorTech (https://ventor.tech)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+# Re-export all exception classes from OCA's queue_job so that connector code
+# importing from integration_queue_job.exception continues to work without
+# modification after the module is renamed.
+from odoo.addons.queue_job.exception import (  # noqa: F401
+    BaseQueueJobError,
+    ChannelNotFound,
+    FailedJobError,
+    JobError,
+    NoSuchJobError,
+    RetryableJobError,
+)

--- a/integration_queue_job_bridge/job.py
+++ b/integration_queue_job_bridge/job.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 VentorTech (https://ventor.tech)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+# Re-export the Job class and related symbols from OCA's queue_job so that
+# connector code importing from integration_queue_job.job continues to work
+# without modification after the module is renamed.
+from odoo.addons.queue_job.job import (  # noqa: F401
+    Job,
+    identity_exact,
+    CANCELLED,
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_PRIORITY,
+    DONE,
+    ENQUEUED,
+    FAILED,
+    PENDING,
+    RETRY_INTERVAL,
+    STARTED,
+    WAIT_DEPENDENCIES,
+)

--- a/integration_queue_job_bridge/post_init_hook.py
+++ b/integration_queue_job_bridge/post_init_hook.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 VentorTech (https://ventor.tech)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+# XML IDs that VentorTech connector modules reference with the
+# "integration_queue_job" module prefix.  We create ir.model.data aliases so
+# that those references resolve to the records actually owned by OCA's
+# queue_job module.
+_ALIASES = [
+    # (alias_name, model, source_xmlid)
+    ('channel_root', 'queue.job.channel', 'queue_job.channel_root'),
+    ('group_queue_job_manager', 'res.groups', 'queue_job.group_queue_job_manager'),
+]
+
+
+def post_init_hook(env):
+    """Create XML-ID aliases under the 'integration_queue_job' namespace.
+
+    VentorTech connectors reference records such as
+    ``integration_queue_job.channel_root`` and
+    ``integration_queue_job.group_queue_job_manager`` in their XML data files
+    and view definitions.  When this bridge module is installed (renamed to
+    ``integration_queue_job``) those aliases are created here so every
+    existing reference continues to resolve without any changes to the
+    connector modules themselves.
+    """
+    IrModelData = env['ir.model.data']
+
+    for name, model, source_xmlid in _ALIASES:
+        record = env.ref(source_xmlid, raise_if_not_found=False)
+        if not record:
+            _logger.warning(
+                'integration_queue_job bridge: source record %s not found, '
+                'skipping alias creation for %s.',
+                source_xmlid, name,
+            )
+            continue
+
+        existing = IrModelData.search([
+            ('module', '=', 'integration_queue_job'),
+            ('name', '=', name),
+        ])
+        if existing:
+            _logger.debug(
+                'integration_queue_job bridge: alias %s already exists, skipping.',
+                name,
+            )
+            continue
+
+        IrModelData.create({
+            'name': name,
+            'module': 'integration_queue_job',
+            'model': model,
+            'res_id': record.id,
+            'noupdate': True,
+        })
+        _logger.info(
+            'integration_queue_job bridge: created alias integration_queue_job.%s '
+            '-> %s (id=%s).',
+            name, source_xmlid, record.id,
+        )


### PR DESCRIPTION
Add integration_queue_job_bridge module and repository README.

The bridge module is a lightweight shim that delegates all functionality to OCA's queue_job module. When copied and renamed to integration_queue_job, its post_init_hook creates ir.model.data XML-ID aliases so that VentorTech connector modules continue to resolve integration_queue_job.channel_root and integration_queue_job.group_queue_job_manager without any code changes.

Also add README.md explaining both modules and the step-by-step migration process for switching from the standalone fork to OCA's implementation.