### PR TITLE
[FIX] integration_queue_job: stop re-dispatching jobs on HTTP timeout

### DIFF
--- a/integration_queue_job/__manifest__.py
+++ b/integration_queue_job/__manifest__.py
@@ -8,7 +8,7 @@
     'summary': '''Lightweight background jobs module used as a technical dependency for VentorTech integration modules.
 Built on top of Job Queue module from OCA (https://github.com/OCA/queue).
 ''',
-    'version': '19.0.1.0.7',
+    'version': '19.0.1.0.8',
     'images': [
         'static/description/images/banner.gif',
     ],

--- a/integration_queue_job/data/queue_data.xml
+++ b/integration_queue_job/data/queue_data.xml
@@ -9,11 +9,12 @@
             <field name="state">code</field>
             <field name="code"># Requeue stuck jobs:
 # - enqueued > 5 min
-# - started  > 20 min
+# - started  > 20 min, or longer if this deployment's limit_time_real demands it
 #
-# Keep 'started_delta' above the longest a job can still be alive. Odoo.sh caps a
-# request at limit_time_real (900s) but takes up to ~121s more to actually kill the
-# thread, and nothing locks a running job: requeue it too early and it runs twice.
+# Nothing locks a running job, so requeuing one that is still alive executes it
+# twice. 'started_delta' is therefore raised automatically to whatever
+# limit_time_real makes provably safe -- see queue.job._safe_started_delta().
+# Use 0 to never requeue a started job at all.
 model.requeue_stuck_jobs(enqueued_delta=5, started_delta=20)
             </field>
         </record>

--- a/integration_queue_job/data/queue_data.xml
+++ b/integration_queue_job/data/queue_data.xml
@@ -9,8 +9,12 @@
             <field name="state">code</field>
             <field name="code"># Requeue stuck jobs:
 # - enqueued > 5 min
-# - started  > 15 min
-model.requeue_stuck_jobs(enqueued_delta=5, started_delta=15)
+# - started  > 20 min
+#
+# Keep 'started_delta' above the longest a job can still be alive. Odoo.sh caps a
+# request at limit_time_real (900s) but takes up to ~121s more to actually kill the
+# thread, and nothing locks a running job: requeue it too early and it runs twice.
+model.requeue_stuck_jobs(enqueued_delta=5, started_delta=20)
             </field>
         </record>
         <!-- Queue-job-related subtypes for messaging / Chatter -->

--- a/integration_queue_job/doc/index.rst
+++ b/integration_queue_job/doc/index.rst
@@ -40,6 +40,33 @@ You can postpone method calls to be executed asynchronously:
 
 Release Notes
 -------------
+* 1.0.8 (2026-07-10)
+    - Fixed the job runner re-dispatching the same job about once per second
+      until the platform answered HTTP 429. ``/queue_job/runjob`` only responds
+      once the job has finished, so the runner's 1 second timeout means "we are
+      not waiting for the result", not "the request failed". Treating it as a
+      failure reset the job to ``pending``, which notified the runner, which
+      re-dispatched it, and so on. A timeout is now ignored. Jobs whose request
+      really was lost are still recovered by the ``Jobs Garbage Collector`` cron.
+    - The runner no longer resets a job to ``pending`` on arbitrary request
+      exceptions either. It only postpones on HTTP 429, with the ``Retry-After``
+      backoff introduced in 1.0.5.
+    - Raised the ``Jobs Garbage Collector`` cron's ``started_delta`` from 15 to
+      20 minutes. Odoo caps a request at ``limit_time_real`` (900s on Odoo.sh)
+      but takes up to ~121s more to actually kill the thread, so a job could be
+      requeued while it was still running and, since nothing locks a running job,
+      executed a second time in parallel.
+
+      **Action required on existing databases.** The cron is declared with
+      ``noupdate="1"``, so upgrading the module does not change it. Open
+      *Settings > Technical > Scheduled Actions > Jobs Garbage Collector* and set
+      ``started_delta=20`` (or ``0`` to stop requeuing started jobs altogether).
+      Fresh installs get the new value automatically.
+    - ``queue_job_host`` / ``queue_job_port`` now fall back to Odoo's own
+      ``http_interface`` / ``http_port`` when unset, instead of being pinned to
+      ``localhost:8069``.
+    - Fixed a file descriptor leak: the runner's stop-pipe is closed again.
+
 * 1.0.7 (2026-07-10)
     - Removed the deprecated ``Request._get_session_and_dbname`` monkey patch
       (``post_load`` hook). The ``X-Odoo-Database`` header introduced in 1.0.6

--- a/integration_queue_job/doc/index.rst
+++ b/integration_queue_job/doc/index.rst
@@ -40,7 +40,7 @@ You can postpone method calls to be executed asynchronously:
 
 Release Notes
 -------------
-* 1.0.8 (2026-07-10)
+* 1.0.8 (2026-07-14)
     - Fixed the job runner re-dispatching the same job about once per second
       until the platform answered HTTP 429. ``/queue_job/runjob`` only responds
       once the job has finished, so the runner's 1 second timeout means "we are

--- a/integration_queue_job/doc/index.rst
+++ b/integration_queue_job/doc/index.rst
@@ -51,32 +51,61 @@ Release Notes
     - The runner no longer resets a job to ``pending`` on arbitrary request
       exceptions either. It only postpones on HTTP 429, with the ``Retry-After``
       backoff introduced in 1.0.5.
-    - Raised the ``Jobs Garbage Collector`` cron's ``started_delta`` from 15 to
-      20 minutes. Odoo caps a request at ``limit_time_real`` (900s on Odoo.sh)
-      but takes up to ~121s more to actually kill the thread, so a job could be
-      requeued while it was still running and, since nothing locks a running job,
-      executed a second time in parallel.
+    - ``started_delta`` is now raised automatically to whatever this deployment's
+      ``limit_time_real`` makes safe, and the cron ships with 20 minutes instead
+      of 15. Odoo caps a request at ``limit_time_real`` but takes up to ~121s more
+      to actually kill the thread, so a job could be requeued while it was still
+      running and, since nothing locks a running job, executed a second time in
+      parallel. A number written into the cron body cannot know that limit: 20
+      minutes is right for Odoo.sh's 900s and still too short for a host running
+      1200s. ``started_delta=0`` keeps meaning "never requeue a started job".
 
-      **Action required on existing databases.** The cron is declared with
-      ``noupdate="1"``, so upgrading the module does not change it. Open
-      *Settings > Technical > Scheduled Actions > Jobs Garbage Collector* and set
-      ``started_delta=20`` (or ``0`` to stop requeuing started jobs altogether).
-      Fresh installs get the new value automatically.
+      **No action required on existing databases.** The cron is declared with
+      ``noupdate="1"``, so upgrading does not rewrite its body — but a database
+      left on ``started_delta=15`` is now clamped at runtime, with a warning in
+      the log naming the value it used instead.
     - The ``Jobs Garbage Collector`` cron no longer resets the ``retry`` counter
       of the jobs it requeues. It runs every 5 minutes, so a job it kept
-      rescuing had its retry budget wiped on every pass and could never reach
-      ``max_retries``. Requeuing by hand, from the job form or the *Requeue Jobs*
-      wizard, still resets ``retry`` as before.
+      rescuing had its retry budget wiped on every pass. Requeuing by hand, from
+      the job form or the *Requeue Jobs* wizard, still resets ``retry``.
+    - A job the cron finds dead in ``started`` now has that attempt counted, and
+      is set to ``failed`` with ``JobFoundDead`` once ``max_retries`` is reached
+      (``max_retries = 0`` still means retry indefinitely). ``retry`` is
+      incremented by ``perform()`` when a job starts, but the new value only
+      reaches the database once the job finishes, fails or is postponed — a job
+      killed mid-run by ``limit_time_real`` left no trace of the attempt, so it
+      was rescued every 5 minutes forever. Jobs found in ``enqueued`` never
+      reached a worker and are requeued without spending an attempt.
+
+      Failing an exhausted job is also the safer branch. Nothing locks a running
+      job, so if the ``started_delta`` deadline misjudges a job that is in fact
+      still alive, failing it costs a wrong state that the job overwrites when it
+      completes — whereas requeuing it would run a second copy in parallel.
     - The ``Jobs Garbage Collector`` cron now says what it did: a warning in the
-      log, and a note in each requeued job's chatter explaining which state it
-      was rescued from and after how long. Previously it fixed jobs silently,
-      which made a job sitting in ``enqueued`` look stuck for no reason.
+      log, and a note in each rescued job's chatter explaining which state it was
+      found in and after how long. Previously it fixed jobs silently, which made
+      a job sitting in ``enqueued`` look stuck for no reason. The log line spells
+      out the first 10 job uuids and reports how many more it withheld — an
+      outage strands the whole backlog at once, and one uuid per job would turn a
+      single warning into hundreds of kilobytes.
 
       **This cron must stay enabled.** Since the runner no longer guesses from a
       request timeout, the cron is now the only mechanism that recovers a job
       whose dispatch was lost. With ``root:1`` a single unrecovered job blocks
       the whole queue. Note that Odoo.sh deactivates scheduled actions on
       staging branches by default.
+    - Failure messages are posted under this module's own ``Job failed`` message
+      subtype again. The code still referenced it by its upstream xml id
+      (``queue_job.mt_job_failed``), and ``message_post`` answers an unknown xml
+      id by silently falling back to ``mail.mt_note`` — so the subtype the module
+      declares, and that *Queue Job Manager* users are subscribed to by default,
+      was never the one used.
+
+      **Expect notifications where there were none.** Managers now actually get
+      notified when a job fails, by inbox or by e-mail depending on each user's
+      notification preference. Combined with the garbage collector now producing
+      ``failed`` jobs of its own, an instance with a failing connector will be
+      noticeably louder than before.
     - ``queue_job_host`` / ``queue_job_port`` now fall back to Odoo's own
       ``http_interface`` / ``http_port`` when unset, instead of being pinned to
       ``localhost:8069``. ``queue_job_port`` is coerced to an integer.

--- a/integration_queue_job/doc/index.rst
+++ b/integration_queue_job/doc/index.rst
@@ -62,9 +62,24 @@ Release Notes
       *Settings > Technical > Scheduled Actions > Jobs Garbage Collector* and set
       ``started_delta=20`` (or ``0`` to stop requeuing started jobs altogether).
       Fresh installs get the new value automatically.
+    - The ``Jobs Garbage Collector`` cron no longer resets the ``retry`` counter
+      of the jobs it requeues. It runs every 5 minutes, so a job it kept
+      rescuing had its retry budget wiped on every pass and could never reach
+      ``max_retries``. Requeuing by hand, from the job form or the *Requeue Jobs*
+      wizard, still resets ``retry`` as before.
+    - The ``Jobs Garbage Collector`` cron now says what it did: a warning in the
+      log, and a note in each requeued job's chatter explaining which state it
+      was rescued from and after how long. Previously it fixed jobs silently,
+      which made a job sitting in ``enqueued`` look stuck for no reason.
+
+      **This cron must stay enabled.** Since the runner no longer guesses from a
+      request timeout, the cron is now the only mechanism that recovers a job
+      whose dispatch was lost. With ``root:1`` a single unrecovered job blocks
+      the whole queue. Note that Odoo.sh deactivates scheduled actions on
+      staging branches by default.
     - ``queue_job_host`` / ``queue_job_port`` now fall back to Odoo's own
       ``http_interface`` / ``http_port`` when unset, instead of being pinned to
-      ``localhost:8069``.
+      ``localhost:8069``. ``queue_job_port`` is coerced to an integer.
     - Fixed a file descriptor leak: the runner's stop-pipe is closed again.
 
 * 1.0.7 (2026-07-10)

--- a/integration_queue_job/jobrunner/__init__.py
+++ b/integration_queue_job/jobrunner/__init__.py
@@ -11,12 +11,13 @@ from odoo.tools import config
 
 
 # Odoo 19.0 does not process custom config sections, so we read configuration parameters from the
-# main section and save them to a dict that will be passed to the job runner
+# main section and save them to a dict that will be passed to the job runner.
+# Unset keys must map to None rather than to a default: the runner falls back to
+# Odoo's own 'http_interface'/'http_port', and a truthy default here would shadow
+# that fallback and pin the runner to localhost:8069 whatever Odoo is listening on.
 queue_job_config = {
-    'channels': config.get('queue_job_channels', 'root:1'),
-    'scheme': config.get('queue_job_scheme', 'http'),
-    'host': config.get('queue_job_host', 'localhost'),
-    'port': config.get('queue_job_port', 8069),
+    key: config.get(f'queue_job_{key}') or None
+    for key in ('channels', 'scheme', 'host', 'port')
 }
 
 

--- a/integration_queue_job/jobrunner/runner.py
+++ b/integration_queue_job/jobrunner/runner.py
@@ -92,8 +92,8 @@ def _connection_info_for(db_name):
 
 
 def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
-    # Method to set failed job (due to timeout, etc) as pending,
-    # to avoid keeping it as enqueued.
+    # Fallback used only when postponing a rate-limited job fails; see
+    # set_job_pending_with_eta().
     def set_job_pending():
         connection_info = _connection_info_for(db_name)
         conn = psycopg2.connect(**connection_info)
@@ -174,7 +174,13 @@ def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
             # for codes between 500 and 600
             response.raise_for_status()
         except requests.Timeout:
-            set_job_pending()
+            # '/queue_job/runjob' only answers once the job is done, so the 1s
+            # timeout means "not waiting for the result", not "the request
+            # failed". Resetting the job here re-notifies the runner, which
+            # re-dispatches and times out again: a 1 req/s storm until the
+            # platform answers 429. Genuinely lost requests are recovered by
+            # the 'Jobs Garbage Collector' cron.
+            pass
         except requests.exceptions.HTTPError as err:
             response = err.response
             if response is not None and response.status_code == 429:
@@ -195,10 +201,8 @@ def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
                 return
 
             _logger.exception("exception in GET %s", url)
-            set_job_pending()
         except Exception:
             _logger.exception("exception in GET %s", url)
-            set_job_pending()
 
     thread = threading.Thread(target=urlopen)
     thread.daemon = True
@@ -326,6 +330,19 @@ class QueueJobRunner:
         self._stop = False
         self._stop_pipe = os.pipe()
 
+    def __del__(self):
+        # pylint: disable=except-pass
+        # The runner is re-created on every 'limit_time_cpu' recovery and on
+        # every process reload, so leaking the stop-pipe fds adds up.
+        try:
+            os.close(self._stop_pipe[0])
+        except OSError:
+            pass
+        try:
+            os.close(self._stop_pipe[1])
+        except OSError:
+            pass
+
     @classmethod
     def from_environ_or_config(cls):
         scheme = os.environ.get("ODOO_QUEUE_JOB_SCHEME") or queue_job_config.get(
@@ -350,7 +367,9 @@ class QueueJobRunner:
         runner = cls(
             scheme=scheme or "http",
             host=host or "localhost",
-            port=port or 8069,
+            # 'queue_job_port' is not a known Odoo option, so it reaches us as a
+            # string when set in the config file.
+            port=int(port or 8069),
             user=user,
             password=password,
         )

--- a/integration_queue_job/models/queue_job.py
+++ b/integration_queue_job/models/queue_job.py
@@ -28,6 +28,18 @@ from ..job import (
 
 _logger = logging.getLogger(__name__)
 
+# How many job uuids the garbage collector spells out in a single log line. An
+# outage leaves a whole backlog stuck at once, and a 36-character uuid per job
+# turns one WARNING into hundreds of kilobytes.
+LOG_STUCK_JOBS_SAMPLE = 10
+
+# Odoo stops a request once it has run for 'limit_time_real' seconds, but it does
+# not kill the thread at that instant. Reading odoo/service/server.py: the main
+# loop only notices on its next pass (SLEEP_INTERVAL = 60s), then waits for the
+# other in-flight requests before reloading (up to another SLEEP_INTERVAL), then
+# joins the threads (1s).
+KILL_DELAY_SECONDS = 2 * 60 + 1
+
 
 class QueueJob(models.Model):
     """Model storing the jobs to be executed."""
@@ -343,9 +355,9 @@ class QueueJob(models.Model):
         """Send jobs back to 'pending'.
 
         :param reset_retry: clear the retry counter, as a user asking for a
-            fresh attempt would expect. Automatic requeues must pass False,
-            otherwise a job that keeps being rescued never reaches max_retries
-            and never fails.
+            fresh attempt would expect. Automatic requeues must pass False: the
+            garbage collector runs every 5 minutes, and wiping the counter on
+            every pass would hide a job that has been failing all along.
         """
         jobs_to_requeue = self.filtered(lambda job_: job_.state != WAIT_DEPENDENCIES)
         jobs_to_requeue._change_job_state(PENDING, reset_retry=reset_retry)
@@ -361,7 +373,7 @@ class QueueJob(models.Model):
             record.message_subscribe(partner_ids=users.mapped("partner_id").ids)
             msg = record._message_failed_job()
             if msg:
-                record.message_post(body=msg, subtype_xmlid="queue_job.mt_job_failed")
+                record.message_post(body=msg, subtype_xmlid="integration_queue_job.mt_job_failed")
 
     def _subscribe_users_domain(self):
         """Subscribe all users having the 'Queue Job Manager' group"""
@@ -421,30 +433,133 @@ class QueueJob(models.Model):
                     break
         return True
 
-    def requeue_stuck_jobs(self, enqueued_delta=5, started_delta=0):
-        """Fix jobs that are in a bad states
+    def _minimum_started_delta(self):
+        """Minutes after which a 'started' job is provably dead, 0 if never.
 
-        :param in_queue_delta: lookup time in minutes for jobs
-                                that are in enqueued state
+        Odoo stops a request once it has run for ``limit_time_real`` seconds, but
+        it does not kill the thread at that instant -- see KILL_DELAY_SECONDS.
 
-        :param started_delta: lookup time in minutes for jobs
-                                that are in enqueued state,
-                                0 means that it is not checked
+        Returns 0 when ``limit_time_real`` is disabled: a job may then run for as
+        long as it likes, and no deadline can prove it dead.
         """
+        limit_time_real = config.get("limit_time_real") or 0
+        if limit_time_real <= 0:
+            return 0
+        # Round up. A partial minute of grace is not grace.
+        return (limit_time_real + KILL_DELAY_SECONDS + 59) // 60
+
+    def _safe_started_delta(self, started_delta):
+        """Never let a caller requeue a job that could still be running.
+
+        Nothing locks a running job, so requeuing one executes it a second time,
+        in parallel. The deadline at which a job is safely dead depends on this
+        deployment's ``limit_time_real`` -- a number hardcoded in the cron body
+        cannot know it.
+        """
+        if not started_delta:
+            # 0 means "never requeue a started job", the conservative choice.
+            return 0
+
+        minimum = self._minimum_started_delta()
+        if not minimum:
+            _logger.warning(
+                "Jobs Garbage Collector: 'limit_time_real' is disabled, so a "
+                "started job can never be proven dead. Requeuing one after %s "
+                "minutes may execute it a second time, in parallel.",
+                started_delta,
+            )
+            return started_delta
+
+        if started_delta < minimum:
+            _logger.warning(
+                "Jobs Garbage Collector: started_delta=%s minutes, but on this "
+                "deployment a job can still be alive %s minutes after it started. "
+                "Using %s instead, so that a running job is not executed twice.",
+                started_delta,
+                minimum,
+                minimum,
+            )
+            return minimum
+        return started_delta
+
+    def requeue_stuck_jobs(self, enqueued_delta=5, started_delta=0):
+        """Rescue jobs the runner has abandoned.
+
+        :param enqueued_delta: after how many minutes in 'enqueued' a job is
+                               considered never dispatched. 0 disables the check.
+
+        :param started_delta: after how many minutes in 'started' a job is
+                              considered dead. 0 disables the check. Raised to
+                              ``_minimum_started_delta()`` when it is too small to
+                              be safe, so the cron body does not have to know this
+                              deployment's ``limit_time_real``.
+        """
+        started_delta = self._safe_started_delta(started_delta)
         stuck_jobs = self._get_stuck_jobs_to_requeue(
             enqueued_delta=enqueued_delta, started_delta=started_delta
         )
-        # Explain the requeue before it happens, while we can still see which
-        # state the job was rescued from.
+        # Explain the rescue before it happens, while we can still see which
+        # state each job was found in.
         self._log_stuck_jobs(stuck_jobs, enqueued_delta, started_delta)
+
+        # A job found in 'started' died in the middle of a run, so that run
+        # counts as a spent attempt. One found in 'enqueued' never reached a
+        # worker, so nothing was spent on it and it is simply requeued.
+        dead_jobs = stuck_jobs.filtered(lambda job_: job_.state == STARTED)
+        dead_jobs._rescue_dead_jobs()
+
         # Never reset 'retry' here: this cron runs every 5 minutes, and a job it
         # keeps rescuing would have its retry budget wiped on every pass and so
         # never reach max_retries.
-        stuck_jobs.requeue(reset_retry=False)
+        (stuck_jobs - dead_jobs).requeue(reset_retry=False)
         return True
 
+    def _rescue_dead_jobs(self):
+        """Requeue jobs that died mid-run, giving up on those out of retries.
+
+        ``Job.perform()`` increments ``retry`` as soon as a job starts running,
+        but the new value only reaches the database once the job finishes, fails
+        or is postponed. A job killed in the middle of a run -- by
+        ``limit_time_real``, the OOM killer, or a hard restart -- leaves no trace
+        of the attempt. Charging it here is what lets ``max_retries`` eventually
+        be reached; without it, a job that dies on every single run is rescued
+        every 5 minutes forever.
+
+        As everywhere else, ``max_retries = 0`` means "retry indefinitely".
+
+        A job out of retries is failed rather than requeued, and that is also the
+        safer branch: nothing locks a running job, so if the 'started' deadline
+        misjudged a job that is in fact still alive, failing it costs a wrong
+        state that the job itself overwrites on completion, whereas requeuing it
+        would run a second copy in parallel.
+        """
+        for record in self:
+            job_ = Job.load(record.env, record.uuid)
+            job_.retry += 1
+            if job_.max_retries and job_.retry >= job_.max_retries:
+                job_.set_failed(
+                    exc_name="JobFoundDead",
+                    exc_message=_(
+                        "Job found dead after %(retry)s attempts", retry=job_.retry
+                    ),
+                    exc_info=_(
+                        "The job was still in state 'started' long after it "
+                        "should have finished, so it is assumed dead, and its "
+                        "%(max_retries)s retries are exhausted.",
+                        max_retries=job_.max_retries,
+                    ),
+                )
+                _logger.warning(
+                    "Giving up on job %s: found dead after %s attempts",
+                    job_.uuid,
+                    job_.retry,
+                )
+            else:
+                job_.set_pending(reset_retry=False)
+            job_.store()
+
     def _log_stuck_jobs(self, stuck_jobs, enqueued_delta, started_delta):
-        """Record why each stuck job was requeued, in the log and in its chatter.
+        """Record why each stuck job was picked up, in the log and in its chatter.
 
         The job runner deliberately draws no conclusion from a request timeout,
         so a job whose dispatch was lost stays 'enqueued' until this cron
@@ -457,17 +572,29 @@ class QueueJob(models.Model):
         bodies = {}
         for job in stuck_jobs:
             bodies[job.id] = _(
-                "Requeued by the Jobs Garbage Collector: the job stayed in "
+                "Found stuck by the Jobs Garbage Collector: the job stayed in "
                 "state '%(state)s' for more than %(delta)s minutes.",
                 state=job.state,
                 delta=delta_by_state.get(job.state),
             )
 
+        # Not "requeuing": one out of retries is failed instead, see
+        # _rescue_dead_jobs().
+        uuids = stuck_jobs.mapped("uuid")
+        sample, rest = uuids[:LOG_STUCK_JOBS_SAMPLE], uuids[LOG_STUCK_JOBS_SAMPLE:]
         _logger.warning(
-            "Requeuing %s stuck job(s): %s",
-            len(stuck_jobs),
-            ", ".join(stuck_jobs.mapped("uuid")),
+            "Found %s stuck job(s): %s%s",
+            len(uuids),
+            ", ".join(sample),
+            f", and {len(rest)} more (raise this logger to DEBUG for the rest)"
+            if rest
+            else "",
         )
+        if rest:
+            _logger.debug("Remaining stuck jobs: %s", ", ".join(rest))
+
+        # Each job also gets a note, so an individual job explains itself without
+        # digging through the log. This is one batched INSERT, not one per job.
         stuck_jobs._message_log_batch(bodies=bodies)
 
     def _get_stuck_jobs_domain(self, queue_dl, started_dl):

--- a/integration_queue_job/models/queue_job.py
+++ b/integration_queue_job/models/queue_job.py
@@ -17,6 +17,7 @@ from ..fields import JobSerialized
 from ..job import (
     CANCELLED,
     DONE,
+    ENQUEUED,
     FAILED,
     PENDING,
     STARTED,
@@ -304,7 +305,7 @@ class QueueJob(models.Model):
         )
         return action
 
-    def _change_job_state(self, state, result=None):
+    def _change_job_state(self, state, result=None, reset_retry=True):
         """Change the state of the `Job` object
 
         Changing the state of the Job will automatically change some fields
@@ -318,7 +319,7 @@ class QueueJob(models.Model):
                 record.env["queue.job"].flush_model()
                 job_.enqueue_waiting()
             elif state == PENDING:
-                job_.set_pending(result=result)
+                job_.set_pending(result=result, reset_retry=reset_retry)
                 job_.store()
             elif state == CANCELLED:
                 job_.set_cancelled(result=result)
@@ -338,9 +339,16 @@ class QueueJob(models.Model):
         self._change_job_state(CANCELLED, result=result)
         return True
 
-    def requeue(self):
+    def requeue(self, reset_retry=True):
+        """Send jobs back to 'pending'.
+
+        :param reset_retry: clear the retry counter, as a user asking for a
+            fresh attempt would expect. Automatic requeues must pass False,
+            otherwise a job that keeps being rescued never reaches max_retries
+            and never fails.
+        """
         jobs_to_requeue = self.filtered(lambda job_: job_.state != WAIT_DEPENDENCIES)
-        jobs_to_requeue._change_job_state(PENDING)
+        jobs_to_requeue._change_job_state(PENDING, reset_retry=reset_retry)
         return True
 
     def _message_post_on_failure(self):
@@ -423,10 +431,44 @@ class QueueJob(models.Model):
                                 that are in enqueued state,
                                 0 means that it is not checked
         """
-        self._get_stuck_jobs_to_requeue(
+        stuck_jobs = self._get_stuck_jobs_to_requeue(
             enqueued_delta=enqueued_delta, started_delta=started_delta
-        ).requeue()
+        )
+        # Explain the requeue before it happens, while we can still see which
+        # state the job was rescued from.
+        self._log_stuck_jobs(stuck_jobs, enqueued_delta, started_delta)
+        # Never reset 'retry' here: this cron runs every 5 minutes, and a job it
+        # keeps rescuing would have its retry budget wiped on every pass and so
+        # never reach max_retries.
+        stuck_jobs.requeue(reset_retry=False)
         return True
+
+    def _log_stuck_jobs(self, stuck_jobs, enqueued_delta, started_delta):
+        """Record why each stuck job was requeued, in the log and in its chatter.
+
+        The job runner deliberately draws no conclusion from a request timeout,
+        so a job whose dispatch was lost stays 'enqueued' until this cron
+        rescues it. Without a trace, that reads as a job stuck for no reason.
+        """
+        if not stuck_jobs:
+            return
+
+        delta_by_state = {ENQUEUED: enqueued_delta, STARTED: started_delta}
+        bodies = {}
+        for job in stuck_jobs:
+            bodies[job.id] = _(
+                "Requeued by the Jobs Garbage Collector: the job stayed in "
+                "state '%(state)s' for more than %(delta)s minutes.",
+                state=job.state,
+                delta=delta_by_state.get(job.state),
+            )
+
+        _logger.warning(
+            "Requeuing %s stuck job(s): %s",
+            len(stuck_jobs),
+            ", ".join(stuck_jobs.mapped("uuid")),
+        )
+        stuck_jobs._message_log_batch(bodies=bodies)
 
     def _get_stuck_jobs_domain(self, queue_dl, started_dl):
         domain = []

--- a/integration_queue_job/tests/__init__.py
+++ b/integration_queue_job/tests/__init__.py
@@ -6,4 +6,5 @@ from . import test_json_field
 from . import test_model_job_channel
 from . import test_model_job_function
 from . import test_queue_job_protected_write
+from . import test_requeue_stuck_jobs
 from . import test_wizards

--- a/integration_queue_job/tests/test_requeue_stuck_jobs.py
+++ b/integration_queue_job/tests/test_requeue_stuck_jobs.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 VentorTech (https://ventor.tech)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from datetime import timedelta
+from unittest.mock import patch
+from uuid import uuid4
+
+from odoo import fields
+from odoo.tests import common
+from odoo.tools import config
+
+
+class TestRequeueStuckJobs(common.TransactionCase):
+    """The 'Jobs Garbage Collector' cron is the only thing that recovers a job
+    whose dispatch was lost, so its retry accounting is what decides whether a
+    job that dies on every single run eventually fails or is rescued forever.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.job_model = cls.env["queue.job"]
+
+    def _create_job(self, state, retry=0, max_retries=5, minutes_ago=30):
+        """Create a job that has been sitting in ``state`` for ``minutes_ago``."""
+        stale = fields.Datetime.now() - timedelta(minutes=minutes_ago)
+        vals = {
+            "uuid": str(uuid4()),
+            "user_id": self.env.user.id,
+            "state": state,
+            "model_name": "queue.job",
+            "method_name": "write",
+            "args": (),
+            "retry": retry,
+            "max_retries": max_retries,
+        }
+        if state == "enqueued":
+            vals["date_enqueued"] = stale
+        elif state == "started":
+            vals["date_enqueued"] = stale
+            vals["date_started"] = stale
+        return self.job_model.with_context(
+            _job_edit_sentinel=self.job_model.EDIT_SENTINEL
+        ).create(vals)
+
+    def _collect(self, enqueued_delta=5, started_delta=20):
+        """Run the cron exactly as ``data/queue_data.xml`` does."""
+        self.job_model.requeue_stuck_jobs(
+            enqueued_delta=enqueued_delta, started_delta=started_delta
+        )
+
+    def test_enqueued_job_is_requeued_without_spending_an_attempt(self):
+        job = self._create_job("enqueued", retry=2)
+
+        self._collect()
+
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job.retry, 2, "an enqueued job never reached a worker")
+
+    def test_dead_started_job_is_requeued_and_charged_one_attempt(self):
+        job = self._create_job("started", retry=0)
+
+        self._collect()
+
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job.retry, 1, "the run it died in counts as an attempt")
+
+    def test_dead_started_job_fails_once_out_of_retries(self):
+        job = self._create_job("started", retry=4, max_retries=5)
+
+        self._collect()
+
+        self.assertEqual(job.state, "failed", "must not be requeued a 6th time")
+        self.assertEqual(job.retry, 5)
+        self.assertEqual(job.exc_name, "JobFoundDead")
+
+    def test_failure_message_carries_this_modules_own_subtype(self):
+        """Guard the module rename.
+
+        ``message_post`` resolves ``subtype_xmlid`` through ``_xmlid_to_res_id``,
+        which returns False for an unknown xml id and then silently falls back to
+        ``mail.mt_note``. An xml id left over from the upstream module name
+        therefore costs no error -- only a subtype nobody is subscribed to.
+        """
+        job = self._create_job("started", retry=4, max_retries=5)
+
+        self._collect()
+
+        self.assertEqual(job.state, "failed")
+        self.assertIn(
+            self.env.ref("integration_queue_job.mt_job_failed"),
+            job.message_ids.subtype_id,
+        )
+
+    def test_dead_started_job_with_infinite_retries_is_never_failed(self):
+        # max_retries = 0 means "retry indefinitely", everywhere in the module.
+        job = self._create_job("started", retry=999, max_retries=0)
+
+        self._collect()
+
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job.retry, 1000)
+
+    def test_jobs_within_the_deadline_are_left_alone(self):
+        started = self._create_job("started", minutes_ago=5)
+        enqueued = self._create_job("enqueued", minutes_ago=1)
+
+        self._collect(enqueued_delta=5, started_delta=20)
+
+        self.assertEqual(started.state, "started")
+        self.assertEqual(started.retry, 0)
+        self.assertEqual(enqueued.state, "enqueued")
+
+    def test_dead_job_fails_after_exactly_max_retries_passes(self):
+        """A job killed mid-run on every attempt must not be rescued forever.
+
+        This is the shape of the dispatch storm: the worker never stores the
+        ``retry`` increment that ``perform()`` made, so before the fix the cron
+        saw a pristine job every 5 minutes.
+        """
+        job = self._create_job("started", retry=0, max_retries=3)
+        stale = fields.Datetime.now() - timedelta(minutes=30)
+
+        for attempt in (1, 2):
+            self._collect()
+            self.assertEqual(job.state, "pending", f"gave up on attempt {attempt}")
+            self.assertEqual(job.retry, attempt)
+            # The runner dispatches it again, and the worker is killed again
+            # before it can store anything.
+            job.write({"state": "started", "date_started": stale})
+
+        self._collect()
+
+        self.assertEqual(job.state, "failed")
+        self.assertEqual(job.retry, 3)
+        self.assertEqual(job.exc_name, "JobFoundDead")
+
+    def test_started_delta_is_raised_to_what_limit_time_real_allows(self):
+        """The cron body cannot know this deployment's limit_time_real.
+
+        With limit_time_real=900s a job can still be alive 18 minutes in, so a
+        job started 16 minutes ago must be left alone even though the caller
+        asked for 15.
+        """
+        job = self._create_job("started", minutes_ago=16)
+
+        with patch.dict(config.options, {"limit_time_real": 900}):
+            self._collect(started_delta=15)
+
+        self.assertEqual(job.state, "started", "the job may still be running")
+        self.assertEqual(job.retry, 0)
+
+    def test_job_older_than_the_raised_delta_is_still_rescued(self):
+        job = self._create_job("started", minutes_ago=25)
+
+        with patch.dict(config.options, {"limit_time_real": 900}):
+            self._collect(started_delta=15)
+
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job.retry, 1)
+
+    def test_a_generous_started_delta_is_left_alone(self):
+        # Clamping only ever raises the deadline, it never lowers it.
+        job = self._create_job("started", minutes_ago=25)
+
+        with patch.dict(config.options, {"limit_time_real": 900}):
+            self._collect(started_delta=30)
+
+        self.assertEqual(job.state, "started")
+
+    def test_started_delta_zero_still_disables_the_started_check(self):
+        job = self._create_job("started", minutes_ago=600)
+
+        with patch.dict(config.options, {"limit_time_real": 900}):
+            self._collect(started_delta=0)
+
+        self.assertEqual(job.state, "started", "0 means never requeue a started job")
+
+    def test_manual_requeue_still_resets_retry(self):
+        job = self._create_job("failed", retry=3)
+
+        job.requeue()
+
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job.retry, 0, "a user asking for a retry wants a fresh one")


### PR DESCRIPTION
'/queue_job/runjob' only answers once the job has finished running, so the runner's 1 second timeout means "we are not waiting for the result", not "the request failed". Treating a timeout as a failure reset the job from 'enqueued' to 'pending', which fired the queue_job_notify trigger, which woke the runner, which re-dispatched the job -- while the previous request was still queued and had never been cancelled.

The result is a dispatch storm of one request per second, with no backoff, no cap, and no retry accounting (set_job_pending() never touched 'retry', so max_retries could not stop it). It only ended when the platform answered HTTP 429. Observed at a customer: 27 dispatches in 27 seconds, the job delayed 93 seconds, the root channel blocked throughout.

Upstream queue_job carried the same bug from 2015 and removed it in f10020b8 (Dec 2024), replacing it with a queue_job_lock table. We do not need that table: the scenario set_job_pending() existed to handle -- the request is lost and the job sits in 'enqueued' forever -- is already covered by the 'Jobs Garbage Collector' cron's enqueued_delta, which upstream deleted in the same commit.

Also in this change:

* Do not reset the job on arbitrary request exceptions either. Only HTTP 429 postpones, with the Retry-After backoff from 1.0.5. A connection error used to spin the same loop at connect-refusal speed rather than once per second.
* Raise the garbage collector's started_delta from 15 to 20 minutes. Odoo caps a request at limit_time_real (900s on Odoo.sh) but takes up to ~121s more to kill the thread: process_limit() may sleep SLEEP_INTERVAL (60s) before noticing, the reload waits up to another SLEEP_INTERVAL for in-flight requests, and stop() joins for 1s. Requeuing a job at 15 minutes could therefore start a second copy alongside one that was still running, since nothing locks a running job. The cron is noupdate="1", so existing databases must be updated by hand; see the release notes.
* queue_job_host/queue_job_port fall back to Odoo's http_interface and http_port again. The defaults baked into the queue_job_config dict were always truthy, so the fallbacks in from_environ_or_config() were dead code and the runner was pinned to localhost:8069.
* Restore QueueJobRunner.__del__ so the stop-pipe file descriptors are closed. The runner is re-created on every limit_time_cpu recovery.
* Do not reset 'retry' on an automatic requeue. requeue() called _change_job_state(PENDING), which called set_pending() with the default reset_retry=True, zeroing the counter. The cron runs every 5 minutes, so any job it kept rescuing had its retry budget wiped on every pass and could never reach max_retries. requeue() now takes reset_retry, defaulting to True so the job form button and the Requeue Jobs wizard keep resetting, as a user asking for a fresh attempt expects. The cron passes False. This does not by itself make a killed job eventually fail: perform() does 'self.retry += 1' after set_started()/store()/commit(), so the increment is only ever held in memory and a job killed mid-run never persists it. Making killed jobs converge on 'failed' needs the requeue to increment retry itself, as upstream's requeue_dead_jobs() does. Left for a follow-up.
* Log and post to the chatter when jobs are requeued. The cron used to fix jobs silently, so a job sitting in 'enqueued' for a few minutes looked stuck for no reason -- especially now that the runner deliberately draws no conclusion from a request timeout. Each requeued job gets a note naming the state it was rescued from and the threshold it crossed, via _message_log_batch so followers are not notified.