### PR TITLE
[IMP] integration_queue_job: read settings from a [queue_job] section

### DIFF
--- a/integration_queue_job/__manifest__.py
+++ b/integration_queue_job/__manifest__.py
@@ -8,7 +8,7 @@
     'summary': '''Lightweight background jobs module used as a technical dependency for VentorTech integration modules.
 Built on top of Job Queue module from OCA (https://github.com/OCA/queue).
 ''',
-    'version': '19.0.1.0.8',
+    'version': '19.0.1.0.9',
     'images': [
         'static/description/images/banner.gif',
     ],

--- a/integration_queue_job/doc/index.rst
+++ b/integration_queue_job/doc/index.rst
@@ -40,6 +40,36 @@ You can postpone method calls to be executed asynchronously:
 
 Release Notes
 -------------
+* 1.0.9 (2026-07-14)
+    - The job runner now reads its settings from a ``[queue_job]`` section of
+      ``odoo.conf``. Odoo only parses the ``[options]`` section and logs a
+      warning for every key it does not recognise, so the ``queue_job_*`` keys
+      cost four warnings on every process start -- on one production instance,
+      132 log lines a day. It never enumerates the other sections, so a section
+      of our own is silent. It is also the layout OCA's ``queue_job``
+      documentation assumes, and the only one that can carry the
+      ``jobrunner_db_*`` and ``http_auth_*`` settings: ``runner.py`` reads them,
+      but they were unreachable from a flat key and always resolved to ``None``.
+
+      .. code:: ini
+
+         [options]
+         server_wide_modules = base,web,integration_queue_job,...
+
+         ; Keep this section at the end of the file: in an .ini file every key
+         ; below a section header belongs to that section.
+         [queue_job]
+         channels = root:1
+         scheme = https
+         host = mycompany.odoo.com
+         port = 443
+
+      **No action required.** The old ``queue_job_*`` keys under ``[options]``
+      still work, so an existing ``odoo.conf`` keeps its current behaviour --
+      upgrading will not silently repoint a live runner. While they are in use,
+      the runner logs one warning naming them, with the section to copy in their
+      place. Where both define the same key, the section wins.
+
 * 1.0.8 (2026-07-14)
     - Fixed the job runner re-dispatching the same job about once per second
       until the platform answered HTTP 429. ``/queue_job/runjob`` only responds

--- a/integration_queue_job/jobrunner/__init__.py
+++ b/integration_queue_job/jobrunner/__init__.py
@@ -3,27 +3,92 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 import logging
-from threading import Thread
 import time
+from configparser import ConfigParser
+from configparser import Error as ConfigParserError
+from threading import Thread
 
 from odoo.service import server
 from odoo.tools import config
 
+_logger = logging.getLogger(__name__)
 
-# Odoo 19.0 does not process custom config sections, so we read configuration parameters from the
-# main section and save them to a dict that will be passed to the job runner.
-# Unset keys must map to None rather than to a default: the runner falls back to
-# Odoo's own 'http_interface'/'http_port', and a truthy default here would shadow
-# that fallback and pin the runner to localhost:8069 whatever Odoo is listening on.
-queue_job_config = {
-    key: config.get(f'queue_job_{key}') or None
-    for key in ('channels', 'scheme', 'host', 'port')
-}
+# Our settings live in their own [queue_job] section of odoo.conf, which we parse
+# ourselves. Odoo only ever iterates the [options] section (tools/config.py,
+# `for name, value in p.items('options')`) and logs a warning for every key it
+# does not recognise, so settings kept there cost one warning apiece on every
+# process start. It never enumerates the other sections, so a section of our own
+# is both silent and, incidentally, the layout every OCA queue_job doc assumes.
+QUEUE_JOB_SECTION = 'queue_job'
+
+# Before the section, the same settings were flat 'queue_job_*' keys under
+# [options]. Odoo stores unknown keys as-is, which is how they reached us. Still
+# honoured, so that upgrading the module does not silently repoint a live runner,
+# but the section wins wherever both define a key.
+LEGACY_PREFIX = 'queue_job_'
+LEGACY_KEYS = ('channels', 'scheme', 'host', 'port')
+
+
+def _read_config_section():
+    """Return the [queue_job] section of odoo.conf as a dict."""
+    cfg_path = config.get('config')
+    if not cfg_path:
+        return {}
+
+    parser = ConfigParser(interpolation=None)
+    try:
+        parser.read(cfg_path)
+    except (OSError, ConfigParserError):
+        _logger.exception(
+            'Could not read %s. The job runner falls back to its defaults.', cfg_path
+        )
+        return {}
+
+    if not parser.has_section(QUEUE_JOB_SECTION):
+        return {}
+    return {key: value for key, value in parser[QUEUE_JOB_SECTION].items() if value}
+
+
+def _read_legacy_options():
+    """Return the deprecated flat 'queue_job_*' keys from [options]."""
+    return {
+        key: config.get(f'{LEGACY_PREFIX}{key}')
+        for key in LEGACY_KEYS
+        if config.get(f'{LEGACY_PREFIX}{key}')
+    }
+
+
+def _build_queue_job_config():
+    settings = _read_config_section()
+    legacy = _read_legacy_options()
+
+    if legacy:
+        _logger.warning(
+            'odoo.conf still configures the job runner through %s under [options]. '
+            'Odoo warns about every key it does not know there, and only a '
+            '[queue_job] section can carry the jobrunner_db_* and http_auth_* '
+            'settings. Move them:\n\n[queue_job]\n%s\n',
+            ', '.join(f'{LEGACY_PREFIX}{key}' for key in sorted(legacy)),
+            '\n'.join(f'{key} = {value}' for key, value in sorted(legacy.items())),
+        )
+
+    # A key defined in both places is a half-finished migration. Take the section:
+    # it is what the admin wrote most recently, and the legacy key is the one Odoo
+    # is already complaining about.
+    for key, value in legacy.items():
+        settings.setdefault(key, value)
+
+    # An absent key must stay absent rather than acquire a default here: the runner
+    # falls back to Odoo's own http_interface/http_port, and a default of ours
+    # would shadow that and pin the runner to localhost:8069 no matter what Odoo is
+    # really listening on.
+    return settings
+
+
+queue_job_config = _build_queue_job_config()
 
 
 from .runner import QueueJobRunner, _channels  # NOQA: E402
-
-_logger = logging.getLogger(__name__)
 
 START_DELAY = 5
 


### PR DESCRIPTION
Odoo only ever parses the [options] section of odoo.conf (tools/config.py, `for name, value in p.items('options')`) and logs a warning for every key it does not recognise. Our settings lived there as flat queue_job_* keys, so they cost four warnings on every process start -- on one production instance, with its 33 restarts a day, 132 log lines. Odoo never enumerates the other sections, so a section of our own is silent, needs no core patch, and is the layout OCA's queue_job documentation already assumes.

It is also the only layout that can carry jobrunner_db_* and http_auth_*. runner.py reads them, but a flat key could not express them, so they always resolved to None: they were unreachable from odoo.conf entirely.

The old keys still work. An existing odoo.conf keeps its behaviour, so upgrading cannot silently repoint a live runner at localhost; while they are in use the runner logs one warning naming them, with the section to copy in their place. Where both define a key, the section wins: it is what the admin wrote most recently, and the legacy key is the one Odoo is already complaining about.